### PR TITLE
RDSHDT-2720: Add stage ring support

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare ring-specific scripts
         run: |
-          RINGS=("dev" "test" "ea" "ga")
+          RINGS=("dev" "test" "stage" "ea" "ga")
           
           for ring in "${RINGS[@]}"; do
             echo "Processing ring: $ring"
@@ -53,7 +53,7 @@ jobs:
 
       - name: Deploy to ring directories
         run: |
-          RINGS=("dev" "test" "ea" "ga")
+          RINGS=("dev" "test" "stage" "ea" "ga")
           
           for ring in "${RINGS[@]}"; do
             echo "Deploying $ring ring"
@@ -124,7 +124,16 @@ jobs:
                       <li><a href="./test/windows-installer.ps1">windows-installer.ps1</a></li>
                   </ul>
               </div>
-              
+
+              <div class="ring">
+                  <h2>🟠 Stage</h2>
+                  <ul class="script-list">
+                      <li><a href="./stage/linux-installer.sh">linux-installer.sh</a></li>
+                      <li><a href="./stage/macos-installer.sh">macos-installer.sh</a></li>
+                      <li><a href="./stage/windows-installer.ps1">windows-installer.ps1</a></li>
+                  </ul>
+              </div>
+
               <div class="ring">
                   <h2>🟡 Early Access (ea)</h2>
                   <ul class="script-list">
@@ -185,6 +194,7 @@ jobs:
             ### Available Rings:
             - **dev**: https://outsystems.github.io/outsystems-hybrid-provision/dev/
             - **test**: https://outsystems.github.io/outsystems-hybrid-provision/test/
+            - **stage**: https://outsystems.github.io/outsystems-hybrid-provision/stage/
             - **ea**: https://outsystems.github.io/outsystems-hybrid-provision/ea/
             - **ga**: https://outsystems.github.io/outsystems-hybrid-provision/ga/
             

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -87,8 +87,8 @@ jobs:
             irm ${repoUrl}/pr/windows-installer.ps1 | iex
             \`\`\`
             
-            **Default Environment:** dev  
-            **Available Environments:** dev, test, ea, ga`;
+            **Default Environment:** dev
+            **Available Environments:** dev, test, stage, ea, ga`;
             
             github.rest.issues.createComment({
               issue_number: prNumber,

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The OutSystems Self-Hosted Operator installer provides platform-specific scripts
 #### Linux/macOS Options
 ```bash
 --version=VERSION        # SHO version to install/manage (default: latest)
---env=ENVIRONMENT       # Environment: test, ea, ga (default: ga)
+--env=ENVIRONMENT       # Environment: dev, test, stage, ea, ga (default: ga)
 --operation=OPERATION   # Operation: install, uninstall, get-console-url (default: install)
 --help, -h              # Show help message
 ```
@@ -88,7 +88,7 @@ The OutSystems Self-Hosted Operator installer provides platform-specific scripts
 #### Windows PowerShell Options
 ```powershell
 --version=VERSION        # SHO version to install/manage (default: latest)
---env=ENVIRONMENT       # Environment: test, ea, ga (default: ga)
+--env=ENVIRONMENT       # Environment: dev, test, stage, ea, ga (default: ga)
 --operation=OPERATION   # Operation: install, uninstall, get-console-url (default: install)
 --help, -h              # Show help message
 ```

--- a/scripts/linux-installer.sh
+++ b/scripts/linux-installer.sh
@@ -21,6 +21,7 @@ DEFAULT_SH_MONITORING="false"  # Enable self-hosted monitoring alerts - Currentl
 ECR_ALIAS_GA="j0s5s8b0/ga"    # GA ECR alias
 ECR_ALIAS_EA="m5i8c6m7/ea"    # EA ECR alias
 ECR_ALIAS_TEST="u4p0z5h7/test"  # Test ECR alias
+ECR_ALIAS_STAGE="u5a4o8b8/stage"  # Stage ECR alias
 ECR_ALIAS_DEV="w0o4m8y0/dev"  # Dev ECR alias
 PUB_REGISTRY="public.ecr.aws"
 
@@ -79,7 +80,7 @@ ${SCRIPT_NAME} v${SCRIPT_VERSION} - OutSystems Self-Hosted Operator for Linux
 
 OPTIONS:
     --version=VERSION        SHO version to install/manage (default: latest)
-    --env=ENVIRONMENT       Environment: test, ea, ga (default: ga)
+    --env=ENVIRONMENT       Environment: dev, test, stage, ea, ga (default: ga)
     --operation=OPERATION   Operation: install, uninstall, get-console-url (default: install)
     --use-acr=BOOLEAN       Use ACR registry: true, false (default: false)
                            [TEMPORARY: Backward compatibility for Azure ACR]
@@ -128,11 +129,11 @@ validate_arguments() {
     fi
     # Validate environment
     case "$ENV" in
-        ga|ea|test|dev)
+        ga|ea|stage|test|dev)
             log_success "Environment '$ENV' is valid"
             ;;
         *)
-            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, test, dev"
+            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, stage, test, dev"
             return 1
             ;;
     esac
@@ -324,12 +325,16 @@ setup_environment() {
             ECR_ALIAS="$ECR_ALIAS_TEST"
             log_info "Using Test ECR alias: $ECR_ALIAS"
             ;;
+        stage)
+            ECR_ALIAS="$ECR_ALIAS_STAGE"
+            log_info "Using Stage ECR alias: $ECR_ALIAS"
+            ;;
         dev)
             ECR_ALIAS="$ECR_ALIAS_DEV"
             log_info "Using Dev ECR alias: $ECR_ALIAS"
             ;;
         *)
-            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, test, dev"
+            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, stage, test, dev"
             exit 1
             ;;
     esac

--- a/scripts/macos-installer.sh
+++ b/scripts/macos-installer.sh
@@ -21,6 +21,7 @@ DEFAULT_SH_MONITORING="false"  # Enable self-hosted monitoring alerts - Currentl
 ECR_ALIAS_GA="j0s5s8b0/ga"    # GA ECR alias
 ECR_ALIAS_EA="m5i8c6m7/ea"    # EA ECR alias
 ECR_ALIAS_TEST="u4p0z5h7/test"  # Test ECR alias
+ECR_ALIAS_STAGE="u5a4o8b8/stage"  # Stage ECR alias
 ECR_ALIAS_DEV="w0o4m8y0/dev"  # Dev ECR alias
 PUB_REGISTRY="public.ecr.aws"
 
@@ -82,7 +83,7 @@ USAGE:
 
 OPTIONS:
     --version=VERSION        SHO version to install/manage (default: latest)
-    --env=ENVIRONMENT       Environment: test, ea, ga (default: ga)
+    --env=ENVIRONMENT       Environment: dev, test, stage, ea, ga (default: ga)
     --operation=OPERATION   Operation: install, uninstall, get-console-url (default: install)
     --use-acr=BOOLEAN       Use ACR registry: true, false (default: false)
                            [TEMPORARY: Backward compatibility for Azure ACR]
@@ -131,11 +132,11 @@ validate_arguments() {
     fi
     # Validate environment
     case "$ENV" in
-        ga|ea|test|dev)
+        ga|ea|stage|test|dev)
             log_success "Environment '$ENV' is valid"
             ;;
         *)
-            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, test, dev"
+            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, stage, test, dev"
             return 1
             ;;
     esac
@@ -328,12 +329,16 @@ setup_environment() {
             ECR_ALIAS="$ECR_ALIAS_TEST"
             log_info "Using Test ECR alias: $ECR_ALIAS"
             ;;
+        stage)
+            ECR_ALIAS="$ECR_ALIAS_STAGE"
+            log_info "Using Stage ECR alias: $ECR_ALIAS"
+            ;;
         dev)
             ECR_ALIAS="$ECR_ALIAS_DEV"
             log_info "Using Dev ECR alias: $ECR_ALIAS"
             ;;
         *)
-            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, test, dev"
+            log_error "Invalid environment: '$ENV'. Must be one of: ga, ea, stage, test, dev"
             exit 1
             ;;
     esac

--- a/scripts/windows-installer.ps1
+++ b/scripts/windows-installer.ps1
@@ -2,7 +2,7 @@
 
 param(
     [string]$version = $null,
-    [ValidateSet("ga", "ea", "test", "dev")]
+    [ValidateSet("ga", "ea", "test", "stage", "dev")]
     [string]$env = "ga",
     [ValidateSet("install", "uninstall", "get-console-url", "stop-port-forward")]
     [string]$operation = "install",
@@ -36,6 +36,7 @@ $Script:ImageName = "self-hosted-operator"
 $Script:EcrAliasGa = "j0s5s8b0/ga"    # GA ECR alias
 $Script:EcrAliasEa = "m5i8c6m7/ea"    # EA ECR alias
 $Script:EcrAliasTest = "u4p0z5h7/test"  # Test ECR alias
+$Script:EcrAliasStage = "u5a4o8b8/stage"  # Stage ECR alias
 $Script:EcrAliasDev = "w0o4m8y0/dev"   # Dev ECR alias
 $Script:PubRegistry = "public.ecr.aws"
 
@@ -105,7 +106,7 @@ USAGE:
 OPTIONS:
 
     -version VERSION        SHO version to install/manage (format: x.y.z, e.g., 0.2.3). If not provided, the latest available version will be used.
-    -env ENVIRONMENT        Environment: ga, ea, test, dev (default: ea)
+    -env ENVIRONMENT        Environment: dev, test, stage, ea, ga (default: ea)
     -operation OPERATION    Operation: install, uninstall, get-console-url (default: install)
     -use-acr BOOLEAN        Use ACR registry: true, false (default: true)
                              [TEMPORARY: Backward compatibility for Azure ACR]
@@ -156,9 +157,10 @@ function Test-Arguments {
         "ga" { Write-LogSuccess "Environment 'ga' is valid" }
         "ea" { Write-LogSuccess "Environment 'ea' is valid" }
         "test" { Write-LogSuccess "Environment 'test' is valid" }
+        "stage" { Write-LogSuccess "Environment 'stage' is valid" }
         "dev" { Write-LogSuccess "Environment 'dev' is valid" }
         default {
-            Write-LogError "Invalid environment: '$Script:Env'. Must be one of: ga, ea, test, dev"
+            Write-LogError "Invalid environment: '$Script:Env'. Must be one of: ga, ea, test, stage, dev"
             return $false
         }
     }
@@ -227,12 +229,16 @@ function Initialize-Environment {
             $Script:EcrAlias = $Script:EcrAliasTest
             Write-LogInfo "Using Test ECR alias: $($Script:EcrAlias)"
         }
+        "stage" {
+            $Script:EcrAlias = $Script:EcrAliasStage
+            Write-LogInfo "Using Stage ECR alias: $($Script:EcrAlias)"
+        }
         "dev" {
             $Script:EcrAlias = $Script:EcrAliasDev
             Write-LogInfo "Using Dev ECR alias: $($Script:EcrAlias)"
         }
         default {
-            Write-LogError "Invalid environment: '$Script:Env'. Must be one of: ga, ea, test, dev"
+            Write-LogError "Invalid environment: '$Script:Env'. Must be one of: ga, ea, test, stage, dev"
             exit 1
         }
     }


### PR DESCRIPTION
## Summary

Add support for the stage deployment ring to the outsystems-hybrid-provision repository. The stage ring enables installation and management of the OutSystems Self-Hosted Operator in stage environments.

**Ring Progression:** dev → test → stage → ea → ga

## Changes

### GitHub Actions Workflows
- Updated `.github/workflows/main-release.yml`:
  - Add stage to RINGS array in script preparation and deployment steps
  - Add stage ring section to GitHub Pages index with 🟠 emoji
  - Update GitHub release notes with stage ring URL

- Updated `.github/workflows/pr-release.yml`:
  - Add stage to available environments in PR preview comments

### Installer Scripts
All three installer scripts (Linux, macOS, Windows) have been updated:
- Add `ECR_ALIAS_STAGE` constant with value: `u5a4o8b8/stage`
- Add stage to environment validation
- Add stage case in setup_environment/Initialize-Environment functions
- Update help text to list: dev, test, stage, ea, ga

Scripts updated:
- `scripts/linux-installer.sh`
- `scripts/macos-installer.sh`
- `scripts/windows-installer.ps1`

### Documentation
- Update `README.md` with stage environment in command-line options

## Installation URLs

Once deployed, the stage ring installer scripts will be available at:
- Linux: https://outsystems.github.io/outsystems-hybrid-provision/stage/linux-installer.sh
- macOS: https://outsystems.github.io/outsystems-hybrid-provision/stage/macos-installer.sh
- Windows: https://outsystems.github.io/outsystems-hybrid-provision/stage/windows-installer.ps1

## Configuration

✅ **Stage ECR Alias:** `u5a4o8b8/stage` (configured)

## Test Plan

- [ ] Verify workflows execute successfully with stage ring included
- [ ] Verify GitHub Pages index displays stage ring section
- [ ] Test `--env=stage` option with installer scripts
- [ ] Verify stage ring is available at the correct GitHub Pages URLs